### PR TITLE
fix(tests): use real timers for pdfParser async PDF extraction

### DIFF
--- a/tests/utils/parsing/pdfParser.test.ts
+++ b/tests/utils/parsing/pdfParser.test.ts
@@ -993,6 +993,10 @@ describe('PdfParser', () => {
     let doc: PDFDocument
 
     beforeEach(async () => {
+      // unpdf uses setImmediate/setTimeout internally; ensure real timers so
+      // vitest's global fakeTimers config does not stall async PDF parsing.
+      vi.useRealTimers()
+
       doc = await PDFDocument.create()
       // Create pages with actual text content
       const page1 = doc.addPage([600, 400])


### PR DESCRIPTION
## Summary

- **Root cause**: vitest's global `fakeTimers` config (`toFake: [setImmediate, clearImmediate, setTimeout, ...]`) stalled `unpdf`'s internal async timing when the full test suite ran in CI, causing `extractText > should extract text as array (one string per page) by default` to hit the 5000ms vitest timeout
- **Fix**: Added `vi.useRealTimers()` in a `beforeEach` scoped to `describe('extractText', ...)` — no paired `vi.useFakeTimers()` needed since no test in this file relies on fake timers
- **Scope**: Single `beforeEach` added inside the `extractText` describe block in `tests/utils/parsing/pdfParser.test.ts`

## Test plan

- [x] `bunx vitest run tests/utils/parsing/pdfParser.test.ts` — 80/80 pass
- [x] `bunx vitest run` (full suite) — 2232/2232 pass, 0 failures
- [x] `bun install --frozen-lockfile` — clean
- [x] `bun run build` — success

🤖 Generated with [Claude Code](https://claude.com/claude-code)