### PR TITLE
fix(tests): narrow vitest fakeTimers to Date; opt-in per-describe where needed

### DIFF
--- a/tests/utils/parsing/pdfParser.test.ts
+++ b/tests/utils/parsing/pdfParser.test.ts
@@ -993,10 +993,6 @@ describe('PdfParser', () => {
     let doc: PDFDocument
 
     beforeEach(async () => {
-      // unpdf uses setImmediate/setTimeout internally; ensure real timers so
-      // vitest's global fakeTimers config does not stall async PDF parsing.
-      vi.useRealTimers()
-
       doc = await PDFDocument.create()
       // Create pages with actual text content
       const page1 = doc.addPage([600, 400])

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -34,15 +34,7 @@ export default defineConfig({
       },
     },
     fakeTimers: {
-      toFake: [
-        'setTimeout',
-        'clearTimeout',
-        'setInterval',
-        'clearInterval',
-        'setImmediate',
-        'clearImmediate',
-        'Date',
-      ],
+      toFake: ['Date'],
     },
   },
 })


### PR DESCRIPTION
## Summary

- Narrows `vitest.config.ts` global `fakeTimers.toFake` from 7 timers (setTimeout/clearTimeout/setInterval/clearInterval/setImmediate/clearImmediate/Date) down to `['Date']` only
- Removes the now-redundant `vi.useRealTimers()` + comment from `pdfParser.test.ts` `extractText` beforeEach (the global narrowing makes it unnecessary)
- No per-describe opt-ins required: zero tests in the suite use `vi.advanceTimersByTime` or `vi.runAllTimers`; TTL compliance tests are currently commented out; scheduler tests mock node-cron tasks directly

## Why

Global setTimeout/setInterval/setImmediate fakery was stalling unpdf/pdf-lib async paths and real-timer-dependent tests (fetchWithTimeout timeout path, storage TTL). PR #9 patched pdfParser extractText with a per-describe `vi.useRealTimers()` workaround; this PR fixes the root cause globally and removes the workaround.

## Test plan

- [x] `bun run test` — 2232 passed, 53 skipped, 0 failed (up from 2231 passed / 1 failed on main)
- [x] `bun install --frozen-lockfile` — clean
- [x] `bun run build` — clean (8.82 MB bundle, 2568 modules)
- [x] Push devcheck hook — Biome, TypeScript, Tests, Unused Deps, Security Audit, Outdated all PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)